### PR TITLE
Feature/miyazu/enable image

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -202,7 +202,8 @@ export class RestAPI {
                               uri: string,
                               data?: SendData<Data>,
                               callback?: ResponseCallback<A>,
-                              requireAuth: boolean = true): Promise<A> {
+                              requireAuth: boolean = true,
+                              decodeJson: boolean = true): Promise<A> {
         const dateNow = new Date();
         const timestampUTC = Math.round(dateNow.getTime() / 1000);
 
@@ -236,7 +237,11 @@ export class RestAPI {
             }
 
             await checkStatus(response);
-            return await parseJSON(response);
+            if (decodeJson) {
+                return await parseJSON(response);
+            } else {
+                return response;
+            }
         }, callback);
     }
 

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -32,7 +32,8 @@ export abstract class Resource {
     protected defineRoute(method: HTTPMethod,
                           path: string,
                           required: string[] = [],
-                          requireAuth: boolean = true): DefinedRoute {
+                          requireAuth: boolean = true,
+                          decodeJson: boolean = true): DefinedRoute {
         const api: RestAPI = this.api;
 
         return function route<A, B>(data?: SendData<A>,
@@ -70,7 +71,7 @@ export abstract class Resource {
                 return Promise.reject(err)
             }
 
-            return api.send(method, url, data, callback, requireAuth)
+            return api.send(method, url, data, callback, requireAuth, decodeJson)
         }
     }
 

--- a/src/resources/TemporaryTokenAlias.ts
+++ b/src/resources/TemporaryTokenAlias.ts
@@ -3,7 +3,7 @@
  */
 
 import { CRUDResource } from "./CRUDResource";
-import { ResponseCallback, SendData, ErrorResponse } from "../api/RestAPI";
+import { ResponseCallback, SendData, ErrorResponse, HTTPMethod } from "../api/RestAPI";
 
 export interface TemporaryTokenAliasItem {
     id?: string;
@@ -17,21 +17,41 @@ export interface TemporaryTokenAliasItem {
     createdOn?: string;
 }
 
+export interface TemporaryTokenAliasShortItem {
+    key?: string;
+    validUntil?: string;
+}
+
 export interface TemporaryTokenAliasCreateParams {
     transactionTokenId: string;
-    validUntil: string;
+    metadata?: any;
+    amount?: number;
+    currency?: string;
+    validUntil?: string;
+}
+
+export enum TemporaryTokenAliasQrLogoType {
+    None       = "None",
+    Centered   = "Centered",
+    Background = "Background"
+}
+
+export interface TemporaryTokenAliasQrOptions {
+    size?: number;
+    logo?: TemporaryTokenAliasQrLogoType;
+    color?: string;
 }
 
 export type ResponseTemporaryTokenAlias = TemporaryTokenAlias;
 
 export class TemporaryTokenAlias extends CRUDResource {
 
-    static requiredParams: string[] = ["transactionTokenId", "validUntil"];
+    static requiredParams: string[] = ["transactionTokenId"];
 
     static routeBase: string = "(/stores/:storeId)/tokens/alias";
 
     create(data: SendData<TemporaryTokenAliasCreateParams>,
-           callback?: ResponseCallback<TemporaryTokenAliasItem>): Promise<TemporaryTokenAliasItem> {
+           callback?: ResponseCallback<TemporaryTokenAliasShortItem>): Promise<TemporaryTokenAliasShortItem> {
         return this._createRoute(TemporaryTokenAlias.requiredParams)(data, callback);
     }
 
@@ -40,6 +60,35 @@ export class TemporaryTokenAlias extends CRUDResource {
         data?: SendData<void>,
         callback?: ResponseCallback<TemporaryTokenAliasItem>): Promise<TemporaryTokenAliasItem> {
         return this._getRoute()(data, callback, ["storeId", "id"], storeId, id)
+    }
+
+    getMedia(storeId: string,
+             id: string,
+             data?: SendData<TemporaryTokenAliasQrOptions>,
+             callback?: ResponseCallback<Blob>): Promise<Blob> {
+        return this.defineRoute(HTTPMethod.GET, `${this._routeBase}/:id`, [], true, false)
+            ({ media: "qr", ...data }, callback, ["storeId", "id"], storeId, id)
+            .then((response: Response) => {
+                return response.blob()
+            })
+    }
+
+    post(storeId: string,
+         id: string,
+         data?: SendData<void>,
+         callback?: ResponseCallback<TemporaryTokenAliasItem>): Promise<TemporaryTokenAliasItem> {
+        return this.defineRoute(HTTPMethod.POST, `${this._routeBase}/:id`)(data, callback, ["storeId", "id"], storeId, id)
+    }
+
+    postMedia(storeId: string,
+              id: string,
+              data?: SendData<TemporaryTokenAliasQrOptions>,
+              callback?: ResponseCallback<Blob>): Promise<Blob> {
+        return this.defineRoute(HTTPMethod.POST, `${this._routeBase}/:id`, [], true, false)
+            ({ media: "qr", ...data }, callback, ["storeId", "id"], storeId, id)
+            .then((response: Response) => {
+                return response.blob()
+            })
     }
 
     delete(storeId: string,


### PR DESCRIPTION
Because the API could return images, responses other than JSON format should also be accepted.
This makes JSON parsing optional and updates TemporaryTokenAlias.